### PR TITLE
Add pagination to get_documents request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logbook_client (0.3.0)
+    logbook_client (0.3.1)
       activesupport (~> 7.0)
       http (~> 5.0)
 
@@ -93,8 +93,7 @@ GEM
     diff-lcs (1.5.0)
     domain_name (0.6.20240107)
     erubi (1.12.0)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.16.3)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake

--- a/lib/logbook_client/api.rb
+++ b/lib/logbook_client/api.rb
@@ -35,10 +35,12 @@ module LogbookClient
       request_with_rescue { Requests::HealthRequest.new }
     end
 
-    def get_documents(collection_id, search_term = '', page: nil)
+    def get_documents(collection_id, search_term = '', page: nil, per_page: nil)
       raise InvalidSearchTermError, 'Search term must be an string' unless search_term.is_a?(String)
 
-      request_with_rescue { Requests::GetDocumentsRequest.new(collection_id, search_term, page:) }
+      request_with_rescue do
+        Requests::GetDocumentsRequest.new(collection_id, search_term, page:, per_page:)
+      end
     end
 
     def get_document(collection_id, document_id)

--- a/lib/logbook_client/api.rb
+++ b/lib/logbook_client/api.rb
@@ -35,11 +35,11 @@ module LogbookClient
       request_with_rescue { Requests::HealthRequest.new }
     end
 
-    def get_documents(collection_id, search_term = '', page: nil, per_page: nil)
+    def get_documents(collection_id, search_term = '', **options)
       raise InvalidSearchTermError, 'Search term must be an string' unless search_term.is_a?(String)
 
       request_with_rescue do
-        Requests::GetDocumentsRequest.new(collection_id, search_term, page:, per_page:)
+        Requests::GetDocumentsRequest.new(collection_id, search_term, **options)
       end
     end
 

--- a/lib/logbook_client/api.rb
+++ b/lib/logbook_client/api.rb
@@ -35,10 +35,10 @@ module LogbookClient
       request_with_rescue { Requests::HealthRequest.new }
     end
 
-    def get_documents(collection_id, search_term = '')
+    def get_documents(collection_id, search_term = '', page: nil)
       raise InvalidSearchTermError, 'Search term must be an string' unless search_term.is_a?(String)
 
-      request_with_rescue { Requests::GetDocumentsRequest.new(collection_id, search_term) }
+      request_with_rescue { Requests::GetDocumentsRequest.new(collection_id, search_term, page:) }
     end
 
     def get_document(collection_id, document_id)
@@ -73,12 +73,16 @@ module LogbookClient
     end
 
     def build_request(request)
-      headers = default_headers.merge(request.respond_to?(:headers) ? request.headers : {})
-      json = (request.respond_to?(:body) && request.body.presence) || {}
-
       HTTP.use(instrumentation: { instrumenter: ActiveSupport::Notifications.instrumenter,
                                   namespace: INSTRUMENT_NAMESPACE })
-          .request(request.method, build_uri(request.path), json:, headers:, **request.options)
+          .request(request.method, build_uri(request.path), **http_request_params(request))
+    end
+
+    def http_request_params(request)
+      { json: (request.respond_to?(:body) && request.body.presence) || {},
+        headers: default_headers.merge(request.respond_to?(:headers) ? request.headers : {}),
+        params: request.respond_to?(:params) ? request.params.presence : {},
+        **(request.respond_to?(:options) ? request.options : {}) }
     end
 
     def raise_error(response)

--- a/lib/logbook_client/helpers/document_helper.rb
+++ b/lib/logbook_client/helpers/document_helper.rb
@@ -5,12 +5,37 @@ module LogbookClient
     module DocumentHelper
       HASH_PARSER_REGEX = /(")|{|}|\s/
 
+      ## General helpers
+
+      # search_terms_to_hash(string) => hash
+      # example:
+      # searchable_term = 'integration_id:009f0ec4-84cd-4fc1-b099-64f76f29b12c,log_type:incoming'
+      # searchable_term_to_hash(searchable_term)
+      # => { integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c', log_type: 'incoming' }
+      def search_term_to_hash(searchable_terms)
+        searchable_terms.split(',').to_h do |term|
+          term.split(':')
+        end.deep_symbolize_keys
+      end
+
+      ## Helpers used on Document class
+
+      # to_reference_id(hash) => string
+      # example:
+      # params = { integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c', log_type: 'incoming' }
+      # to_reference_id(params)
+      # => 'integration_id:009f0ec4-84cd-4fc1-b099-64f76f29b12c--$/#--log_type:incoming'
       def to_reference_id(params)
         raise Error, 'This method only accepts a Hash to be parsed' unless params.is_a?(Hash)
 
         params.to_json.gsub(HASH_PARSER_REGEX, '').gsub(',', separator)
       end
 
+      # to_searchable_terms(hash) => array
+      # example:
+      # params = { integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c', log_type: 'incoming' }
+      # to_searchable_terms(params)
+      # => ['integration_id:009f0ec4-84cd-4fc1-b099-64f76f29b12c', 'log_type:incoming']
       def to_searchable_terms(params_or_reference_id)
         result = if params_or_reference_id.is_a?(String)
                    params_or_reference_id

--- a/lib/logbook_client/requests/get_document_request.rb
+++ b/lib/logbook_client/requests/get_document_request.rb
@@ -12,7 +12,6 @@ module LogbookClient
 
       def method = :get
       def path = format(PATH, collection_id:, document_id:)
-      def options = {}
 
       private
 

--- a/lib/logbook_client/requests/get_documents_request.rb
+++ b/lib/logbook_client/requests/get_documents_request.rb
@@ -5,20 +5,21 @@ module LogbookClient
     class GetDocumentsRequest
       PATH = 'collections/%<collection_id>s/documents'
 
-      def initialize(collection_id, search_term, page: nil)
+      def initialize(collection_id, search_term, page: nil, per_page: nil)
         @collection_id = collection_id
         @search_term = search_term
         @page = page
+        @per_page = per_page
       end
 
       def method = :get
       def path = format(PATH, collection_id:)
       def body = { search: { term: search_term } }
-      def params = { page: }.compact_blank
+      def params = { page:, size: per_page }.compact_blank
 
       private
 
-      attr_reader :collection_id, :search_term, :page
+      attr_reader :collection_id, :search_term, :page, :per_page
     end
   end
 end

--- a/lib/logbook_client/requests/get_documents_request.rb
+++ b/lib/logbook_client/requests/get_documents_request.rb
@@ -5,19 +5,20 @@ module LogbookClient
     class GetDocumentsRequest
       PATH = 'collections/%<collection_id>s/documents'
 
-      def initialize(collection_id, search_term)
+      def initialize(collection_id, search_term, page: nil)
         @collection_id = collection_id
         @search_term = search_term
+        @page = page
       end
 
       def method = :get
       def path = format(PATH, collection_id:)
       def body = { search: { term: search_term } }
-      def options = {}
+      def params = { page: }.compact_blank
 
       private
 
-      attr_reader :collection_id, :search_term
+      attr_reader :collection_id, :search_term, :page
     end
   end
 end

--- a/lib/logbook_client/requests/get_documents_request.rb
+++ b/lib/logbook_client/requests/get_documents_request.rb
@@ -5,11 +5,11 @@ module LogbookClient
     class GetDocumentsRequest
       PATH = 'collections/%<collection_id>s/documents'
 
-      def initialize(collection_id, search_term, page: nil, per_page: nil)
+      def initialize(collection_id, search_term, **options)
         @collection_id = collection_id
         @search_term = search_term
-        @page = page
-        @per_page = per_page
+        @page = options.delete(:page)
+        @per_page = options.delete(:per_page)
       end
 
       def method = :get

--- a/lib/logbook_client/version.rb
+++ b/lib/logbook_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LogbookClient
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/lib/logbook_client/helpers/document_helper_spec.rb
+++ b/spec/lib/logbook_client/helpers/document_helper_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe LogbookClient::Helpers::DocumentHelper, type: :helper do
+  describe '#search_term_to_hash' do
+    subject(:search_term_to_hash) { helper.search_term_to_hash(term) }
+
+    let(:term) { 'integration_id:009f0ec4-84cd-4fc1-b099-64f76f29b12c,log_type:incoming' }
+
+    it do
+      expect(search_term_to_hash).to match(integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c',
+                                           log_type: 'incoming')
+    end
+  end
+end

--- a/spec/lib/logbook_client_spec.rb
+++ b/spec/lib/logbook_client_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe LogbookClient do
   describe 'VERSION' do
-    it { expect(described_class::VERSION).to eq('0.3.0') }
+    it { expect(described_class::VERSION).to eq('0.3.1') }
   end
 
   describe '#to_reference_id' do


### PR DESCRIPTION
#### What?
- **improve the use of headers on api**
- **Add page to get_documents request**

#### Why?
- otherwise, it is impossible to do paginated requests

#### How to test
```rb
irb(main):003> LogbookClient.get_documents('integrations', page: 4, per_page: 5)
=>
{:success=>true,
 :message=>nil,
 :response=>{:total_count=>11, :total_pages=>2, :current_page=>4, :limit_value=>5, :offset_value=>15, :entries=>[]}}

irb(main):013> LogbookClient.get_documents('integrations', page: 3, per_page: 5)
=>
{:success=>true,
 :message=>nil,
 :response=>
  {:total_count=>11,
   :total_pages=>2,
   :current_page=>3,
   :limit_value=>5,
   :offset_value=>10,
   :entries=>
    [{:id=>"8bbb9af2-5ff0-47ca-83c1-c1f3f9ab6cea",
      :collection_id=>"61509724-214b-4681-a68c-e86f11cfeddc",
      :reference=>
       "integration_id:c59158ed-3b65-4e55-9a15-5251c9dfd408--$/#--log_id:8bbb9af2-5ff0-47ca-83c1-c1f3f9ab6cea--$/#--log_type:outgoing--$/#--integration_order_id:4660b143-9ef7-4398-a7dc-44bae090f37a--$/#--external_order_id:0|167653-01",
      :created_at=>"2024-07-05T21:47:14Z",
      :request_method=>nil,
      :uri=>"https://291606e0-1bc1-4586-b686-10a0eeb0f649.mock.pstmn.io:vendor_workflow_event",
      :raw_headers=>{:request_headers=>{:"x-mock-event-code"=>"1", :"x-mock-match-request-headers"=>"x-mock-event-code"}},
      :raw_request_payload=>nil,
      :status=>"000",
      :raw_response_payload=>nil}]}}
```
