### PR TITLE
Adjust rubocop warning, and bump version after bumping rack gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require: rubocop-rspec
+plugins: rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 3.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logbook_client (0.5.1)
+    logbook_client (0.5.2)
       http (~> 5.2)
 
 GEM

--- a/lib/logbook_client/version.rb
+++ b/lib/logbook_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LogbookClient
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/lib/logbook_client_spec.rb
+++ b/spec/lib/logbook_client_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe LogbookClient do
   describe 'VERSION' do
-    it { expect(described_class::VERSION).to eq('0.5.1') }
+    it { expect(described_class::VERSION).to eq('0.5.2') }
   end
 
   describe '#search_term_to_hash' do


### PR DESCRIPTION
#### What?
- **Adjust rubocop warning**
- **bump version to 0.5.2**

