### PR TITLE
Fix reference_id parsing when values contain colons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logbook_client (0.5.6)
+    logbook_client (0.5.7)
       http (~> 5.2)
 
 GEM
@@ -103,9 +103,9 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.3)
     erubi (1.13.1)
-    ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
-    ffi-compiler (1.3.2)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi-compiler (1.4.2)
       ffi (>= 1.15.5)
       rake
     globalid (1.2.1)
@@ -116,7 +116,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-cookie (1.1.0)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     i18n (1.14.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logbook_client (0.5.7)
+    logbook_client (0.6.0)
       http (~> 5.2)
 
 GEM

--- a/lib/logbook_client/helpers/document_helper.rb
+++ b/lib/logbook_client/helpers/document_helper.rb
@@ -25,7 +25,7 @@ module LogbookClient
       # => { integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c', log_type: 'incoming' }
       def reference_id_to_hash(reference_id)
         to_searchable_terms(reference_id).to_h do |term|
-          term.split(':')
+          term.split(':', 2)
         end.deep_symbolize_keys
       end
 

--- a/lib/logbook_client/version.rb
+++ b/lib/logbook_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LogbookClient
-  VERSION = '0.5.7'
+  VERSION = '0.6.0'
 end

--- a/lib/logbook_client/version.rb
+++ b/lib/logbook_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LogbookClient
-  VERSION = '0.5.6'
+  VERSION = '0.5.7'
 end

--- a/spec/lib/logbook_client_spec.rb
+++ b/spec/lib/logbook_client_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe LogbookClient do
   describe 'VERSION' do
-    it { expect(described_class::VERSION).to eq('0.5.7') }
+    it { expect(described_class::VERSION).to eq('0.6.0') }
   end
 
   describe '#search_term_to_hash' do

--- a/spec/lib/logbook_client_spec.rb
+++ b/spec/lib/logbook_client_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe LogbookClient do
   describe 'VERSION' do
-    it { expect(described_class::VERSION).to eq('0.5.6') }
+    it { expect(described_class::VERSION).to eq('0.5.7') }
   end
 
   describe '#search_term_to_hash' do
@@ -26,6 +26,20 @@ RSpec.describe LogbookClient do
     it do
       expect(reference_id_to_hash).to match(integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c',
                                             log_type: 'incoming')
+    end
+
+    context 'when a value in the reference_id contains ":"' do
+      let(:reference_id) do
+        'integration_id:009f0ec4-84cd-4fc1-b099-64f76f29b12c--$/#--log_type:outgoing' \
+          '--$/#--external_order_id:13520360-4545455000AM:1'
+      end
+
+      it do
+        expect(reference_id_to_hash).to \
+          match(integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c',
+                log_type: 'outgoing',
+                external_order_id: '13520360-4545455000AM:1')
+      end
     end
   end
 


### PR DESCRIPTION
#### Why?
Previously, splitting on ':' without a limit would break values containing colons, causing incorrect hash generation. This change limits the split to 2 parts to preserve colons within values while maintaining backward compatibility for standard cases (DarkMatter).

The test case ensures that values like `external_order_id:13520360-4545455000AM:1` are correctly parsed as `external_order_id: '13520360-4545455000AM:1'` instead of being split into multiple hash entries.

