### PR TITLE
Ensure DocumentHelper#search_term_to_hash handle values with ':'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logbook_client (0.6.0)
+    logbook_client (0.6.1)
       http (~> 5.2)
 
 GEM
@@ -103,8 +103,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.3)
     erubi (1.13.1)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.15.5)
     ffi-compiler (1.4.2)
       ffi (>= 1.15.5)
       rake

--- a/lib/logbook_client/helpers/document_helper.rb
+++ b/lib/logbook_client/helpers/document_helper.rb
@@ -14,7 +14,7 @@ module LogbookClient
       # => { integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c', log_type: 'incoming' }
       def search_term_to_hash(searchable_terms)
         searchable_terms.split(',').to_h do |term|
-          term.split(':')
+          term.split(':', 2)
         end.deep_symbolize_keys
       end
 

--- a/lib/logbook_client/version.rb
+++ b/lib/logbook_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LogbookClient
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/lib/logbook_client_spec.rb
+++ b/spec/lib/logbook_client_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe LogbookClient do
   describe 'VERSION' do
-    it { expect(described_class::VERSION).to eq('0.6.0') }
+    it { expect(described_class::VERSION).to eq('0.6.1') }
   end
 
   describe '#search_term_to_hash' do

--- a/spec/lib/logbook_client_spec.rb
+++ b/spec/lib/logbook_client_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe LogbookClient do
       expect(search_term_to_hash).to match(integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c',
                                            log_type: 'incoming')
     end
+
+    context 'when some field contain ":"' do
+      let(:term) do
+        'integration_id:009f0ec4-84cd-4fc1-b099-64f76f29b12c,' \
+          'log_type:incoming,' \
+          'external_order_id:13520355-4545455001AM:1'
+      end
+
+      it do
+        expect(search_term_to_hash).to match(integration_id: '009f0ec4-84cd-4fc1-b099-64f76f29b12c',
+                                             log_type: 'incoming',
+                                             external_order_id: '13520355-4545455001AM:1')
+      end
+    end
   end
 
   describe '#reference_id_to_hash' do


### PR DESCRIPTION
#### What?
- **Ensure the document helper handle values with ':'**
- **Bump version to 0.6.1**
